### PR TITLE
Switch from black to ruff format

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -19,9 +19,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 def infer_bump(changelog_dir: Path) -> str:
     fragments = [
-        f
-        for f in changelog_dir.iterdir()
-        if f.is_file() and f.name != ".gitkeep"
+        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
     ]
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
       - name: Check formatting
-        uses: "lgeiger/black-action@master"
-        with:
-          args: ". -l 79 --check"
+        run: ruff format --check .
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,10 +10,10 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine Nigeria')
     steps:
       - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
       - name: Check formatting
-        uses: "lgeiger/black-action@master"
-        with:
-          args: ". -l 79 --check"
+        run: ruff format --check .
   versioning:
     name: Update versioning
     if: |

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ documentation:
 	myst build docs
 
 format:
-	black . -l 79
+	ruff format .
 
 install:
 	pip install -e .[dev]

--- a/changelog.d/switch-to-ruff.changed.md
+++ b/changelog.d/switch-to-ruff.changed.md
@@ -1,0 +1,1 @@
+Switch from black to ruff format.

--- a/docs/api_utils.py
+++ b/docs/api_utils.py
@@ -67,9 +67,7 @@ def calculate(household: dict, reform: dict) -> dict:
                 if any([math.isinf(value) for value in result]):
                     raise ValueError("Infinite value")
                 else:
-                    household[entity_plural][entity_id][variable_name][
-                        period
-                    ] = result
+                    household[entity_plural][entity_id][variable_name][period] = result
             else:
                 entity_index = population.get_index(entity_id)
                 if variable.value_type == Enum:
@@ -86,17 +84,15 @@ def calculate(household: dict, reform: dict) -> dict:
                 else:
                     entity_result = result.tolist()[entity_index]
 
-                household[entity_plural][entity_id][variable_name][
-                    period
-                ] = entity_result
+                household[entity_plural][entity_id][variable_name][period] = (
+                    entity_result
+                )
         except Exception as e:
             if "axes" in household:
                 pass
             else:
                 logging.warn(f"Error computing {variable_name}: {e}")
-                household[entity_plural][entity_id][variable_name][
-                    period
-                ] = None
+                household[entity_plural][entity_id][variable_name][period] = None
 
     return household
 

--- a/policyengine_ng/variables/marginal_tax_rate.py
+++ b/policyengine_ng/variables/marginal_tax_rate.py
@@ -13,14 +13,10 @@ class marginal_tax_rate(Variable):
         simulation = person.simulation
         adult_index_values = person("adult_index", period)
         DELTA = 1_000
-        mtr_adult_count = parameters(
-            period
-        ).simulation.marginal_tax_rate_adults
+        mtr_adult_count = parameters(period).simulation.marginal_tax_rate_adults
         print(simulation.input_variables)
         for adult_index in range(1, 1 + mtr_adult_count):
-            alt_simulation = simulation.get_branch(
-                f"adult_{adult_index}_pay_rise"
-            )
+            alt_simulation = simulation.get_branch(f"adult_{adult_index}_pay_rise")
             mask = adult_index_values == adult_index
             for variable in simulation.tax_benefit_system.variables:
                 if variable not in simulation.input_variables:
@@ -31,15 +27,11 @@ class marginal_tax_rate(Variable):
                 person("employment_income", period) + mask * DELTA,
             )
             alt_person = alt_simulation.person
-            household_net_income = person.household(
-                "household_net_income", period
-            )
+            household_net_income = person.household("household_net_income", period)
             household_net_income_higher_earnings = alt_person.household(
                 "household_net_income", period
             )
-            increase = (
-                household_net_income_higher_earnings - household_net_income
-            )
+            increase = household_net_income_higher_earnings - household_net_income
             mtr_values += where(mask, 1 - increase / DELTA, 0)
             print(household_net_income)
             print(household_net_income_higher_earnings)

--- a/policyengine_ng/variables/tax/is_tax_exempt.py
+++ b/policyengine_ng/variables/tax/is_tax_exempt.py
@@ -15,7 +15,4 @@ class is_tax_exempt(Variable):
         )
         gross_income = person("gross_income", period)
         has_non_employment_income = gross_income > employment_income
-        return (
-            employment_income_at_or_below_threshold
-            & ~has_non_employment_income
-        )
+        return employment_income_at_or_below_threshold & ~has_non_employment_income

--- a/policyengine_ng/variables/tax/taxable_income.py
+++ b/policyengine_ng/variables/tax/taxable_income.py
@@ -10,7 +10,5 @@ class taxable_income(Variable):
 
     def formula(person, period, parameters):
         gross_income = person("gross_income", period)
-        consolidated_relief_allowance = person(
-            "consolidated_relief_allowance", period
-        )
+        consolidated_relief_allowance = person("consolidated_relief_allowance", period)
         return max_(0, gross_income - consolidated_relief_allowance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "build",
     "jupyter-book>=1.0.4",
     "mystmd>=1.3.17",
+    "ruff>=0.9.0",
     "towncrier>=24.8.0",
 ]
 


### PR DESCRIPTION
## Summary
- Replace black with ruff for code formatting across the project
- Update dev dependencies in pyproject.toml (add `ruff>=0.9.0`)
- Update Makefile `format` target: `black . -l 79` -> `ruff format .`
- Update CI workflows (pr.yaml, push.yaml): replace `lgeiger/black-action` with `ruff format --check .`
- Reformat all files using ruff defaults (line-length 88)

## Test plan
- [x] `ruff format --check .` passes
- [ ] CI lint job passes with new ruff check

🤖 Generated with [Claude Code](https://claude.com/claude-code)