### PR TITLE
Use org-level reusable workflows for lint and changelog

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,27 +4,9 @@ on:
     branches: [master]
 jobs:
   Lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install ruff
-        run: pip install ruff
-      - name: Check formatting
-        run: ruff format --check .
+    uses: PolicyEngine/.github/.github/workflows/lint.yml@main
   check-changelog:
-    name: Check changelog fragment
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check for changelog fragment
-        run: |
-          FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
-          if [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::error::No changelog fragment found in changelog.d/"
-            echo "Add one with: echo 'Description.' > changelog.d/\$(git branch --show-current).<type>.md"
-            echo "Types: added, changed, fixed, removed, breaking"
-            exit 1
-          fi
+    uses: PolicyEngine/.github/.github/workflows/changelog.yml@main
   Test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,16 +4,10 @@ on:
     branches: [master]
 jobs:
   Lint:
-    runs-on: ubuntu-latest
     if: |
       (github.repository == 'PolicyEngine/policyengine-ng')
       && (github.event.head_commit.message == 'Update PolicyEngine Nigeria')
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install ruff
-        run: pip install ruff
-      - name: Check formatting
-        run: ruff format --check .
+    uses: PolicyEngine/.github/.github/workflows/lint.yml@main
   versioning:
     name: Update versioning
     if: |

--- a/changelog.d/use-reusable-workflows.changed.md
+++ b/changelog.d/use-reusable-workflows.changed.md
@@ -1,0 +1,1 @@
+Use org-level reusable GitHub Actions workflows for lint and changelog checks.


### PR DESCRIPTION
## Summary

- Replaces inline Lint and changelog check jobs with calls to org-level reusable workflows from `PolicyEngine/.github`
- The reusable workflows use `uvx ruff format --check .` (replacing `pip install ruff && ruff format --check .`)
- Net deletion of ~23 lines of duplicated YAML

## Dependencies

- Requires PolicyEngine/.github#1 to be merged first

## Test plan

- [ ] Merge PolicyEngine/.github#1 first
- [ ] Verify Lint job passes using the reusable workflow
- [ ] Verify changelog check passes using the reusable workflow
- [ ] Verify Test job is unaffected

Generated with [Claude Code](https://claude.com/claude-code)