### PR TITLE
Mint GitHub App token in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,10 +15,16 @@ jobs:
       && !(github.event.head_commit.message == 'Update PolicyEngine Nigeria')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -37,6 +43,8 @@ jobs:
           committer_name: Github Actions[bot]
           author_name: Github Actions[bot]
           message: Update PolicyEngine Nigeria
+          github_token: ${{ steps.app-token.outputs.token }}
+          fetch: false
   Test:
     runs-on: ${{ matrix.os }}
     if: |
@@ -86,13 +94,17 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-ng')
       && (github.event.head_commit.message == 'Update PolicyEngine Nigeria')
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.POLICYENGINE_GITHUB }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -104,4 +116,4 @@ jobs:
       - name: Update API
         run: python .github/update_api.py
         env:
-          GITHUB_TOKEN: ${{ secrets.POLICYENGINE_GITHUB }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/changed/migrate-to-app-token.md
+++ b/changelog.d/changed/migrate-to-app-token.md
@@ -1,0 +1,1 @@
+Migrated push workflow from the expired `POLICYENGINE_GITHUB` PAT to a short-lived GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`), so the `versioning` job can push the "Update PolicyEngine Nigeria" commit that triggers Test, Publish, and Deploy. Matches the pattern already used by policyengine-core, policyengine-us, microdf, and policyengine-canada.


### PR DESCRIPTION
## Summary
- Replace expired `POLICYENGINE_GITHUB` PAT with a short-lived GitHub App token minted via `actions/create-github-app-token@v1` in the `versioning` and `Deploy` jobs
- Pass the App token to `EndBug/add-and-commit@v9` via `github_token:` and add `fetch: false`
- Drop the stale job-level `env.GH_TOKEN` in `Deploy`; `update_api.py` reads `GITHUB_TOKEN` from its step env

Follows the same pattern already landed in `policyengine-core` #470, `microdf` #296, `policyengine-canada`, `policyengine-us`.

## Test plan
- [ ] CI lint/test pass on this PR
- [ ] After merge, the next `Update PolicyEngine Nigeria` push shows `versioning` and `Deploy` jobs minting a token and succeeding

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>